### PR TITLE
1.17 Add Alternate Sprint Key

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ If you are using multiple Fabric mods I recommend also getting [Mod Menu](https:
 
 Press 'P' to toggle automatic walking. You can also hit the sprint key to sprint while auto-walking.
 
-This keybind can be customized in the controls options.
+Press 'Mouse 5' for an alternate sprint key.
+
+These keybinds can be customized in the controls options.
 
 ## FAQ
 

--- a/src/main/java/com/emonadeo/autorun/AutoRun.java
+++ b/src/main/java/com/emonadeo/autorun/AutoRun.java
@@ -5,6 +5,7 @@ import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.client.option.KeyBinding;
+import net.minecraft.client.option.StickyKeyBinding;
 import net.minecraft.client.util.InputUtil;
 import org.lwjgl.glfw.GLFW;
 
@@ -27,6 +28,7 @@ public class AutoRun implements ClientModInitializer {
     private static Set<MovementDirection> toggled;
     private static long timeActivated;
     private static int delayBuffer;
+    public static KeyBinding altSprintKeybinding;
 
     @Override
     public void onInitializeClient() {
@@ -38,6 +40,12 @@ public class AutoRun implements ClientModInitializer {
                 InputUtil.Type.KEYSYM,
                 GLFW.GLFW_KEY_O, // Default to 'o'
                 "key.categories.movement" // Append movement category
+        ));
+        AutoRun.altSprintKeybinding = KeyBindingHelper.registerKeyBinding(new StickyKeyBinding(
+                "key.autorun.altsprint",
+                GLFW.GLFW_MOUSE_BUTTON_5,
+                "key.categories.movement",
+                () -> {return false;}
         ));
 
         loadConfig(CFG_FILE);

--- a/src/main/java/com/emonadeo/autorun/mixin/AltSprintMixin.java
+++ b/src/main/java/com/emonadeo/autorun/mixin/AltSprintMixin.java
@@ -14,10 +14,9 @@ public abstract class AltSprintMixin {
 
     @Inject(method="isPressed", at = @At("HEAD"), cancellable = true)
     private void injectAltSprint(CallbackInfoReturnable<Boolean> cir) {
-        if (this.getTranslationKey().equals("key.sprint")) {
-            if (AutoRun.altSprintKeybinding.isPressed()) {
-                cir.setReturnValue(true);
-            }
+        if (this.getTranslationKey().equals("key.sprint")
+                && AutoRun.altSprintKeybinding.isPressed()) {
+            cir.setReturnValue(true);
         }
     }
 }

--- a/src/main/java/com/emonadeo/autorun/mixin/AltSprintMixin.java
+++ b/src/main/java/com/emonadeo/autorun/mixin/AltSprintMixin.java
@@ -1,0 +1,23 @@
+package com.emonadeo.autorun.mixin;
+
+import com.emonadeo.autorun.AutoRun;
+import net.minecraft.client.option.KeyBinding;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(KeyBinding.class)
+public abstract class AltSprintMixin {
+    @Shadow public abstract String getTranslationKey();
+
+    @Inject(method="isPressed", at = @At("HEAD"), cancellable = true)
+    private void injectAltSprint(CallbackInfoReturnable<Boolean> cir) {
+        if (this.getTranslationKey().equals("key.sprint")) {
+            if (AutoRun.altSprintKeybinding.isPressed()) {
+                cir.setReturnValue(true);
+            }
+        }
+    }
+}

--- a/src/main/resources/assets/autorun/lang/en_us.json
+++ b/src/main/resources/assets/autorun/lang/en_us.json
@@ -1,5 +1,6 @@
 {
   "key.autorun.toggle": "Toggle AutoRun",
+  "key.autorun.altsprint": "Sprint Alternate",
   "title.autorun.config": "AutoRun",
   "config.autorun.general": "General",
   "config.autorun.delayBuffer": "Delay Buffer",

--- a/src/main/resources/autorun.mixins.json
+++ b/src/main/resources/autorun.mixins.json
@@ -4,6 +4,7 @@
   "package": "com.emonadeo.autorun.mixin",
   "compatibilityLevel": "JAVA_16",
   "mixins": [
+    "AltSprintMixin"
   ],
   "client": [
     "AutoRunMixin"


### PR DESCRIPTION
I added an alternate sprint key because I have found that when I start autorunning I'm generally reaching for something else on my desk. It's nice to have an alternate keybind on the mouse while I reach for a glass of water or something with the other hand, especially when the sprint cancels from other factors. I called it "Sprint Alternate" in the menu so it is right below "Sprint".