### PR TITLE
Fixed "Deactivating Auto-Run" message when changing dimensions

### DIFF
--- a/src/main/java/com/emonadeo/autorun/AutoRunMod.java
+++ b/src/main/java/com/emonadeo/autorun/AutoRunMod.java
@@ -58,7 +58,7 @@ public class AutoRunMod implements ClientModInitializer {
 		ClientTickEvents.END_CLIENT_TICK.register(client -> {
 			while (keyBinding.consumeClick() && client.level != null) {
 				if (forward || backward || left || right) {
-					disableAutoRun(client, true);
+					disableAutoRun(client);
 				} else {
 					enableAutoRun(client);
 					activating = true;
@@ -78,18 +78,22 @@ public class AutoRunMod implements ClientModInitializer {
 			}
 
 			if ((forward || backward) && (client.options.keyUp.isDown() || client.options.keyDown.isDown())) {
-				disableAutoRun(client, true);
+				disableAutoRun(client);
 			}
 			if ((left || right) && (client.options.keyLeft.isDown() || client.options.keyRight.isDown())) {
-				disableAutoRun(client,true);
+				disableAutoRun(client);
 			}
 		});
 
 		ClientEntityEvents.ENTITY_UNLOAD.register((entity, clientWorld) -> {
 			if (entity instanceof LocalPlayer && !persistAutoRun) {
-				disableAutoRun(Minecraft.getInstance(), false);
+				disableAutoRun(Minecraft.getInstance());
 			}
 		});
+	}
+
+	private static boolean isAutoRunActive() {
+		return forward || backward || left || right;
 	}
 
 	private static void enableAutoRun(Minecraft client) {
@@ -127,21 +131,23 @@ public class AutoRunMod implements ClientModInitializer {
 		}
 	}
 
-	private static void disableAutoRun(Minecraft client, Boolean displayMessage) {
-		if (showMessage && displayMessage) {
-			client.player.sendOverlayMessage(Component.literal("Deactivating Auto-Run"));
-		}
+	private static void disableAutoRun(Minecraft client) {
+		if (isAutoRunActive()) {
+			if (showMessage) {
+				client.player.sendOverlayMessage(Component.literal("Deactivating Auto-Run"));
+			}
 
-		forward = false;
-		backward = false;
-		left = false;
-		right = false;
-		sprint = false;
+			forward = false;
+			backward = false;
+			left = false;
+			right = false;
+			sprint = false;
 
-		// Restore Auto-Jump
-		if (toggleAutoJump) {
-			client.options.autoJump().set(originalAutoJumpSetting);
-			client.options.broadcastOptions();
+			// Restore Auto-Jump
+			if (toggleAutoJump) {
+				client.options.autoJump().set(originalAutoJumpSetting);
+				client.options.broadcastOptions();
+			}
 		}
 	}
 

--- a/src/main/java/com/emonadeo/autorun/AutoRunMod.java
+++ b/src/main/java/com/emonadeo/autorun/AutoRunMod.java
@@ -58,7 +58,7 @@ public class AutoRunMod implements ClientModInitializer {
 		ClientTickEvents.END_CLIENT_TICK.register(client -> {
 			while (keyBinding.consumeClick() && client.level != null) {
 				if (forward || backward || left || right) {
-					disableAutoRun(client);
+					disableAutoRun(client, true);
 				} else {
 					enableAutoRun(client);
 					activating = true;
@@ -78,16 +78,16 @@ public class AutoRunMod implements ClientModInitializer {
 			}
 
 			if ((forward || backward) && (client.options.keyUp.isDown() || client.options.keyDown.isDown())) {
-				disableAutoRun(client);
+				disableAutoRun(client, true);
 			}
 			if ((left || right) && (client.options.keyLeft.isDown() || client.options.keyRight.isDown())) {
-				disableAutoRun(client);
+				disableAutoRun(client,true);
 			}
 		});
 
 		ClientEntityEvents.ENTITY_UNLOAD.register((entity, clientWorld) -> {
 			if (entity instanceof LocalPlayer && !persistAutoRun) {
-				disableAutoRun(Minecraft.getInstance());
+				disableAutoRun(Minecraft.getInstance(), false);
 			}
 		});
 	}
@@ -127,8 +127,8 @@ public class AutoRunMod implements ClientModInitializer {
 		}
 	}
 
-	private static void disableAutoRun(Minecraft client) {
-		if (showMessage) {
+	private static void disableAutoRun(Minecraft client, Boolean displayMessage) {
+		if (showMessage && displayMessage) {
 			client.player.sendOverlayMessage(Component.literal("Deactivating Auto-Run"));
 		}
 

--- a/src/main/resources/assets/autorun/lang/en_us.json
+++ b/src/main/resources/assets/autorun/lang/en_us.json
@@ -3,7 +3,7 @@
 	"config.autorun.alwaysSprint": "Always sprint",
 	"config.autorun.alwaysSprint.description": "Always sprint while Auto-Run is active",
 	"config.autorun.persistAutoRun": "Persist Auto-Run",
-	"config.autorun.persistAutoRun.description": "Keep Auto-Run toggled between leaving and joining worlds or servers",
+	"config.autorun.persistAutoRun.description": "Keep Auto-Run toggled across dimensions, between leaving and joining, and after respawning",
 	"config.autorun.showMessage": "Show message",
 	"config.autorun.showMessage.description": "Show a chat message when Auto-Run is toggled",
 	"config.autorun.toggleAutoJump": "Toggle Auto-Jump",


### PR DESCRIPTION
The "Deactivating Auto-Run" message appears when changing dimensions even when it wasn't activated beforehand.
`disableAutoRun` is still called in `ClientEntityEvents.ENTITY_UNLOAD` but now the message is suppressed. 